### PR TITLE
fix(cli): flag `-m` should precede `--module`

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,7 +7,7 @@ use cmd::serve::serve;
 pub mod cmd;
 
 fn cli() -> Command<'static> {
-    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
     Command::new("fluentci-engine")
         .version(VERSION)
         .about(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,14 +11,14 @@ fn cli() -> Command<'static> {
     Command::new("fluentci-engine")
         .version(VERSION)
         .about(
-            r#"  
-            
-       ________                 __  __________   ______            _          
-      / ____/ /_  _____  ____  / /_/ ____/  _/  / ____/___  ____ _(_)___  ___ 
+            r#"
+
+       ________                 __  __________   ______            _
+      / ____/ /_  _____  ____  / /_/ ____/  _/  / ____/___  ____ _(_)___  ___
      / /_  / / / / / _ \/ __ \/ __/ /    / /   / __/ / __ \/ __ `/ / __ \/ _ \
     / __/ / / /_/ /  __/ / / / /_/ /____/ /   / /___/ / / / /_/ / / / / /  __/
-   /_/   /_/\__,_/\___/_/ /_/\__/\____/___/  /_____/_/ /_/\__, /_/_/ /_/\___/ 
-                                                         /____/                  
+   /_/   /_/\__,_/\___/_/ /_/\__/\____/___/  /_____/_/ /_/\__, /_/_/ /_/\___/
+                                                         /____/
 
    A Programmable CI/CD engine without Containers, built on top of Nix ❄️
       "#,
@@ -36,7 +36,7 @@ fn cli() -> Command<'static> {
         )
         .subcommand(
             Command::new("call")
-                .arg(arg!(--module -m <PATH> "path or url to the module to call").required(true))
+                .arg(arg!(-m --module <PATH> "path or url to the module to call").required(true))
                 .arg(
                     Arg::new("command")
                         .multiple_occurrences(true)


### PR DESCRIPTION
```sh
cargo run -p fluentci-engine -- serve

Compiling fluentci-engine v0.4.12 (fluentci-engine/crates/cli)
Finished `dev` profile [unoptimized + debuginfo] target(s) in 7m 29s
Running `target/debug/fluentci-engine serve`
thread 'main' panicked at crates/cli/src/main.rs:39:22:
assertion `left == right` failed: Short flags should precede long flags
  left: Some("module")
 right: None
```


[Second commit](95660e5d4d81c7f5fd1d5d72d2a6dfb154d751d0) is just a quick fix to make clippy happier :sweat_smile: 